### PR TITLE
Port to ROS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(ivcon)
 
-find_package(catkin REQUIRED)
-
-catkin_package()
+find_package(ament_cmake REQUIRED)
 
 add_executable(${PROJECT_NAME} src/ivcon.c)
 target_link_libraries(${PROJECT_NAME} m)
 
 install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin)
+
+ament_package()

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
-<package>
+<package format="2">
   <name>ivcon</name>
-  <version>0.1.7</version>
-  
+  <version>1.0.0</version>
+
   <description>
 
 Mesh Conversion Utility
@@ -19,6 +19,10 @@ are no local modifications to this package.
   <license>GPL</license>
   <url type="website">https://sourceforge.net/projects/ivcon/</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+      <build_type>ament_cmake</build_type>
+  </export>
+
 </package>


### PR DESCRIPTION
Simple port to get this working in ROS2 systems. This PR will need to be retargeted onto a `ros2` branch that a maintainer will have to create.